### PR TITLE
feat: Add GitHub CLI support to base image

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -63,9 +63,21 @@ SSH_KEY_DIR=~/.ssh
 GIT_REPO_URL=
 
 # Git host domain for SSH key configuration
-# Required when using SSH authentication (private repositories)
+# Required when using SSH authentication (private repositories) or GitHub CLI for non-github.com hosts
 # Examples: github.com, gitlab.com, gitlab.example.com, bitbucket.org
 GIT_HOST_DOMAIN=github.com
+
+# =============================================================================
+# GitHub CLI Configuration (Optional)
+# =============================================================================
+
+# GitHub Personal Access Token (PAT) for authenticating the 'gh' CLI
+# If provided, 'gh auth login --with-token' will be attempted on container start.
+# This allows using 'gh' commands like 'gh pr create', 'gh issue list', etc.
+# Required scopes for PAT: repo, read:org, gist (for full functionality)
+# The 'gh' configuration is persisted in ~/.config/gh inside the container,
+# which is part of the host-mounted ~/.claude-code-container volume.
+GH_TOKEN=
 
 # =============================================================================
 # Additional Notes

--- a/containers/Dockerfile
+++ b/containers/Dockerfile
@@ -21,7 +21,14 @@ RUN apt-get update && apt-get install -y \
     jq \
     ca-certificates \
     sudo \
-    openssh-client \
+    openssh-client
+
+# Install GitHub CLI
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
+    && sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+    && apt-get update \
+    && apt-get install -y gh \
     && rm -rf /var/lib/apt/lists/*
 
 RUN npm install -g @anthropic-ai/claude-code

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,7 @@ services:
       - GIT_HOST_DOMAIN
       - WORKSPACE_DIR
       - SSH_KEY_DIR
+      - GH_TOKEN
     stdin_open: true
     tty: true
 
@@ -38,5 +39,6 @@ services:
       - GIT_HOST_DOMAIN
       - WORKSPACE_DIR
       - SSH_KEY_DIR
+      - GH_TOKEN
     stdin_open: true
     tty: true


### PR DESCRIPTION
- Installs `gh` CLI in the base Docker image.
- Updates entrypoint script to authenticate `gh` using `GH_TOKEN` environment variable if provided.
- Ensures `gh` configuration is persisted via the existing `/home/node` volume mount.
- Updates `docker-compose.yml` to pass `GH_TOKEN`.
- Updates `README.md` and `.env.example` with instructions for `GH_TOKEN` and `gh` usage.